### PR TITLE
RMET-3490 :: Add option to override user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The changes documented here do not include those from the original repository.
 ## [1.0.0]
 
 ### Features
+- Add possibility to override the user agent used in `OpenInWebView`'s webview (https://outsystemsrd.atlassian.net/browse/RMET-3490).
 - Add browser events to `OpenInWebView` feature (https://outsystemsrd.atlassian.net/browse/RMET-3432).
 - Add `OpenInWebView` with current features and default UI on Android (https://outsystemsrd.atlassian.net/browse/RMET-3426).
 - Add `Close` feature on iOS (https://outsystemsrd.atlassian.net/browse/RMET-3427).

--- a/dist/definitions.d.ts
+++ b/dist/definitions.d.ts
@@ -39,6 +39,7 @@ export interface WebViewOptions {
     toolbarPosition: ToolbarPosition;
     showNavigationButtons: boolean;
     leftToRight: boolean;
+    customWebViewUserAgent: String | null;
     android: AndroidWebViewOptions;
     iOS: iOSWebViewOptions;
 }

--- a/dist/plugin.cjs
+++ b/dist/plugin.cjs
@@ -66,7 +66,8 @@ const DefaultWebViewOptions = {
   showNavigationButtons: true,
   leftToRight: false,
   android: DefaultAndroidWebViewOptions,
-  iOS: DefaultiOSWebViewOptions
+  iOS: DefaultiOSWebViewOptions,
+  customWebViewUserAgent: null
 };
 const DefaultiOSSystemBrowserOptions = {
   closeButtonText: DismissStyle.DONE,

--- a/dist/plugin.js
+++ b/dist/plugin.js
@@ -67,7 +67,8 @@
     showNavigationButtons: true,
     leftToRight: false,
     android: DefaultAndroidWebViewOptions,
-    iOS: DefaultiOSWebViewOptions
+    iOS: DefaultiOSWebViewOptions,
+    customWebViewUserAgent: null
   };
   const DefaultiOSSystemBrowserOptions = {
     closeButtonText: DismissStyle.DONE,

--- a/dist/plugin.mjs
+++ b/dist/plugin.mjs
@@ -64,7 +64,8 @@ const DefaultWebViewOptions = {
   showNavigationButtons: true,
   leftToRight: false,
   android: DefaultAndroidWebViewOptions,
-  iOS: DefaultiOSWebViewOptions
+  iOS: DefaultiOSWebViewOptions,
+  customWebViewUserAgent: null
 };
 const DefaultiOSSystemBrowserOptions = {
   closeButtonText: DismissStyle.DONE,

--- a/src/android/OSInAppBrowser.kt
+++ b/src/android/OSInAppBrowser.kt
@@ -132,7 +132,8 @@ class OSInAppBrowser: CordovaPlugin() {
                 it.showNavigationButtons ?: true,
                 it.android.allowZoom ?: true,
                 it.android.hardwareBack ?: true,
-                it.android.pauseMedia ?: true
+                it.android.pauseMedia ?: true,
+                it.customWebViewUserAgent
             )
         }
     }

--- a/src/android/OSInAppBrowserWebViewInputArguments.kt
+++ b/src/android/OSInAppBrowserWebViewInputArguments.kt
@@ -13,6 +13,7 @@ data class OSInAppBrowserWebViewInputArguments(
     @SerializedName("toolbarPosition") val toolbarPosition: OSIABToolbarPosition?,
     @SerializedName("leftToRight") val leftToRight: Boolean?,
     @SerializedName("showNavigationButtons") val showNavigationButtons: Boolean?,
+    @SerializedName("customWebViewUserAgent") val customWebViewUserAgent: String?,
     @SerializedName("android") val android: OSInAppBrowserWebViewAndroidOptions
 )
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -17,7 +17,7 @@ allprojects {
 }
 
 dependencies{
-    implementation("com.github.outsystems:osinappbrowser-android:0.0.14@aar")
+    implementation("com.github.outsystems:osinappbrowser-android:0.0.16@aar")
 
     implementation("com.google.android.gms:play-services-auth:21.2.0")
     implementation("com.google.android.gms:play-services-location:21.3.0")

--- a/src/ios/OSInAppBrowser.swift
+++ b/src/ios/OSInAppBrowser.swift
@@ -91,9 +91,8 @@ class OSInAppBrowser: CDVPlugin {
             else {
                 return self.send(error: .inputArgumentsIssue(target: target), for: command.callbackId)
             }
-            
-            let customUserAgent = self.commandDelegate.settings["overrideuseragent"] as? String
-            delegateWebView(url, argumentsModel.toWebViewOptions(with: customUserAgent))
+
+            delegateWebView(url, argumentsModel.toWebViewOptions())
         }
     }
     

--- a/src/ios/OSInAppBrowserInputArgumentsModel.swift
+++ b/src/ios/OSInAppBrowserInputArgumentsModel.swift
@@ -30,6 +30,7 @@ class OSInAppBrowserInputArgumentsComplexModel: OSInAppBrowserInputArgumentsSimp
         let toolbarPosition: OSIABToolbarPosition?
         let leftToRight: Bool?
         let showNavigationButtons: Bool?
+        let customWebViewUserAgent: String?
     }
     
     let options: Options
@@ -56,7 +57,7 @@ extension OSInAppBrowserInputArgumentsComplexModel {
         )
     }
     
-    func toWebViewOptions(with customUserAgent: String?) -> OSIABWebViewOptions {
+    func toWebViewOptions() -> OSIABWebViewOptions {
         OSIABWebViewOptions(
             showURL: self.options.showURL ?? true,
             showToolbar: self.options.showToolbar ?? true,
@@ -73,7 +74,7 @@ extension OSInAppBrowserInputArgumentsComplexModel {
             surpressIncrementalRendering: self.options.iOS.surpressIncrementalRendering ?? false,
             viewStyle: self.options.iOS.viewStyle ?? .defaultValue,
             animationEffect: self.options.iOS.animationEffect ?? .defaultValue,
-            customUserAgent: customUserAgent
+            customUserAgent: self.options.customWebViewUserAgent
         )
     }
 }

--- a/src/www/defaults.ts
+++ b/src/www/defaults.ts
@@ -32,7 +32,8 @@ export const DefaultWebViewOptions: WebViewOptions = {
     leftToRight: false,
 
     android: DefaultAndroidWebViewOptions,
-    iOS: DefaultiOSWebViewOptions
+    iOS: DefaultiOSWebViewOptions,
+    customWebViewUserAgent: null
 }
 
 export const DefaultiOSSystemBrowserOptions: iOSSystemBrowserOptions = {

--- a/src/www/definitions.ts
+++ b/src/www/definitions.ts
@@ -50,6 +50,8 @@ export interface WebViewOptions {
   showNavigationButtons: boolean;
   leftToRight: boolean;
   
+  customWebViewUserAgent: String | null;
+
   android: AndroidWebViewOptions,
   iOS: iOSWebViewOptions
 }


### PR DESCRIPTION
## Description
This PR adds the possibility of overriding the webview's user agent via a new option
## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [x] JavaScript

## Screenshots (if appropriate)
By setting the custom user agent option as 
` Mozilla/5.0 ... SpecialVersion `
you can check it via inspector as `window.navigator.userAgent`

![Screenshot 2024-06-28 at 11 49 18](https://github.com/OutSystems/cordova-outsystems-inappbrowser/assets/101343976/18b00c69-5379-4531-9d61-67777521e12d)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly