### PR TITLE
RMET-3534 InAppBrowser Plugin - Add permission requests and feature to open file chooser to `Open in WebView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The changes documented here do not include those from the original repository.
 ## [1.0.0]
 
 ### Features
+- Add permissions requests and opening file chooser to `OpenInWebView` feature on Android (https://outsystemsrd.atlassian.net/browse/RMET-3534).
 - Add error and loading screens for `OpenInWebView` feature for Android (https://outsystemsrd.atlassian.net/browse/RMET-3492).
 - Add custom error page for `OpenInWebView` feature (https://outsystemsrd.atlassian.net/browse/RMET-3491).
 - Add browser events to `OpenInSystemBrowser` feature on Android (https://outsystemsrd.atlassian.net/browse/RMET-3431).

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -17,7 +17,7 @@ allprojects {
 }
 
 dependencies{
-    implementation("com.github.outsystems:osinappbrowser-android:0.0.23@aar")
+    implementation("com.github.outsystems:osinappbrowser-android:0.0.24@aar")
 
     implementation("androidx.browser:browser:1.8.0")
     implementation("com.google.android.gms:play-services-auth:21.2.0")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updates the dependency to `OSInAppBrowserLib-Android`.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3534

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested on Android 14 (Pixel 7), Android 13 (Samsung A51), and Android 12 (Pixel 3 XL)

MABS build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=ff89f681b2f33941b97e5fe62a0bdf5e355bb834

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly