### PR TITLE
RMET-3472 :: bridge :: remove unnecessary code

### DIFF
--- a/dist/plugin.cjs
+++ b/dist/plugin.cjs
@@ -137,30 +137,11 @@ function openInExternalBrowser(url, success, error) {
 function close(success, error) {
   exec(success, error, "OSInAppBrowser", "close", [{}]);
 }
-function removeAllListeners() {
-  console.log("remove all listeners...");
-  exec(() => {
-  }, () => {
-  }, "OSInAppBrowser", "coolMethod", [{}]);
-}
-async function addListener(eventName, listenerFunc) {
-  console.log("add listener...");
-  exec(() => {
-  }, () => {
-  }, "OSInAppBrowser", "coolMethod", [{ eventName, listenerFunc }]);
-  return {
-    remove: () => {
-      return Promise.resolve();
-    }
-  };
-}
 module.exports = {
   openInWebView,
   openInExternalBrowser,
   openInSystemBrowser,
-  close,
-  removeAllListeners,
-  addListener
+  close
 };
 exports.AndroidAnimation = AndroidAnimation;
 exports.AndroidViewStyle = AndroidViewStyle;

--- a/dist/plugin.js
+++ b/dist/plugin.js
@@ -138,30 +138,11 @@
   function close(success, error) {
     exec(success, error, "OSInAppBrowser", "close", [{}]);
   }
-  function removeAllListeners() {
-    console.log("remove all listeners...");
-    exec(() => {
-    }, () => {
-    }, "OSInAppBrowser", "coolMethod", [{}]);
-  }
-  async function addListener(eventName, listenerFunc) {
-    console.log("add listener...");
-    exec(() => {
-    }, () => {
-    }, "OSInAppBrowser", "coolMethod", [{ eventName, listenerFunc }]);
-    return {
-      remove: () => {
-        return Promise.resolve();
-      }
-    };
-  }
   module.exports = {
     openInWebView,
     openInExternalBrowser,
     openInSystemBrowser,
-    close,
-    removeAllListeners,
-    addListener
+    close
   };
   exports2.AndroidAnimation = AndroidAnimation;
   exports2.AndroidViewStyle = AndroidViewStyle;

--- a/dist/plugin.mjs
+++ b/dist/plugin.mjs
@@ -135,30 +135,11 @@ function openInExternalBrowser(url, success, error) {
 function close(success, error) {
   exec(success, error, "OSInAppBrowser", "close", [{}]);
 }
-function removeAllListeners() {
-  console.log("remove all listeners...");
-  exec(() => {
-  }, () => {
-  }, "OSInAppBrowser", "coolMethod", [{}]);
-}
-async function addListener(eventName, listenerFunc) {
-  console.log("add listener...");
-  exec(() => {
-  }, () => {
-  }, "OSInAppBrowser", "coolMethod", [{ eventName, listenerFunc }]);
-  return {
-    remove: () => {
-      return Promise.resolve();
-    }
-  };
-}
 module.exports = {
   openInWebView,
   openInExternalBrowser,
   openInSystemBrowser,
-  close,
-  removeAllListeners,
-  addListener
+  close
 };
 export {
   AndroidAnimation,

--- a/src/www/web.ts
+++ b/src/www/web.ts
@@ -62,25 +62,9 @@ function close(success: () => void, error: (error: PluginError) => void): void {
   exec(success, error, 'OSInAppBrowser', 'close', [{}])  
 }
 
-function removeAllListeners(): void {
-  console.log("remove all listeners...");
-  exec(()=>{}, () =>{}, 'OSInAppBrowser', 'coolMethod', [{}])
-}
-async function addListener(eventName: 'browserClosed' | 'browserPageLoaded', listenerFunc: () => void): Promise<PluginListenerHandle> {
-  console.log("add listener...");
-  exec(()=>{}, () =>{}, 'OSInAppBrowser', 'coolMethod', [{eventName, listenerFunc}])
-  return {
-    remove: () => {
-      return Promise.resolve();
-    }
-  }
-}
-
 module.exports = {
   openInWebView,
   openInExternalBrowser,
   openInSystemBrowser,
-  close,
-  removeAllListeners,
-  addListener
+  close
 }


### PR DESCRIPTION
## Description
Given that for OutSystems applications we use UI blocks to register and deal with browser events, these bridge methods are no longer necessary

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly