### PR TITLE
RMET-3680 OSInAppBrowserLib-Android - Don't try to resolve activity before opening URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 1.0.1
+
+### Fixes
+- Android: Fix issue where some URLs weren't being open in Custom Tabs and the External Browser (https://outsystemsrd.atlassian.net/browse/RMET-3680)
+
 ## 1.0.0
 
 ### Features

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -17,7 +17,7 @@ allprojects {
 }
 
 dependencies{
-    implementation("com.github.outsystems:osinappbrowser-android:1.0.0@aar")
+    implementation("com.github.outsystems:osinappbrowser-android:1.0.1-dev@aar")
 
     implementation("androidx.browser:browser:1.8.0")
     implementation("com.google.android.gms:play-services-auth:21.2.0")

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -17,7 +17,7 @@ allprojects {
 }
 
 dependencies{
-    implementation("com.github.outsystems:osinappbrowser-android:1.0.1-dev@aar")
+    implementation("com.github.outsystems:osinappbrowser-android:1.0.1@aar")
 
     implementation("androidx.browser:browser:1.8.0")
     implementation("com.google.android.gms:play-services-auth:21.2.0")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR updates `OSInAppBrowserLib-Android` to version `1.0.1`, fixing an issue where some URLs aren't being open in Custom Tabs and the External Browser by removing the verification made with `canOpenUrl`.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3680

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested in Android 15 (Pixel 7).

MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=82ce90ebd3fcd5c99dbdc8f6915324d50410b70a

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
