### PR TITLE
RMET-3887 :: Bump kotlin + gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 1.2.0
+
+### Android
+
+#### Chores
+
+- Bumps Kotlin and Gradle versions (https://outsystemsrd.atlassian.net/browse/RMET-3887).
+
+
 ## 1.1.0
 
 ### Android

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools.build:gradle:8.7.2'
     }
 }
 
@@ -16,7 +16,7 @@ allprojects {
 }
 
 dependencies{
-    implementation("com.github.outsystems:osinappbrowser-android:1.1.0@aar")
+    implementation("com.github.outsystems:osinappbrowser-android:1.2.0@aar")
 
     implementation("androidx.browser:browser:1.8.0")
     implementation("com.google.android.gms:play-services-auth:21.2.0")
@@ -33,7 +33,7 @@ dependencies{
     implementation "androidx.activity:activity-ktx:1.9.3"
 
     // constraint layout
-    implementation "androidx.constraintlayout:constraintlayout:2.2.0-alpha13"
+    implementation "androidx.constraintlayout:constraintlayout:2.2.0"
 
     //gson
     implementation 'com.google.code.gson:gson:2.10.1'


### PR DESCRIPTION
## Description
This PR: 
- bumps gradle + kotlin versions
- prepares the plugin for the `1.2.0` release 

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3887
## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Last builds where made using `1.2.0-dev2`
### OutSystems
- [MABS 10](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=ec07b9ad98a34cc8bddd888465c6fcf9e2d9e170&stg=dev) 
- [MABS 11](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=94cc66a8e8898dc843df52688cd4d05f40237695&stg=dev)

### Capacitor
Tested with inappbrowser's example app


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
