### PR TITLE
RMET-3987 - Remove unnecessary permissions from AndroidManifest.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 1.2.1
+
+### Android
+
+#### Fixes
+
+- Remove unnecessary permissions from AndroidManifest (https://outsystemsrd.atlassian.net/browse/RMET-3987).
+
 ## 1.2.0
 
 ### Android
@@ -13,7 +21,6 @@ The changes documented here do not include those from the original repository.
 #### Chores
 
 - Bumps Kotlin and Gradle versions (https://outsystemsrd.atlassian.net/browse/RMET-3887).
-
 
 ## 1.1.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.inappbrowser",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "InAppBrowser OutSystems Cordova Plugin",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.outsystems.plugins.inappbrowser" version="1.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.inappbrowser" version="1.2.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>cordova-outsystems-inappbrowser</name>
     <description>InAppBrowser OutSystems Cordova Plugin</description>
     <author>OutSystems Inc</author>

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -16,7 +16,7 @@ allprojects {
 }
 
 dependencies{
-    implementation("com.github.outsystems:osinappbrowser-android:1.2.0@aar")
+    implementation("com.github.outsystems:osinappbrowser-android:1.2.0-dev3@aar")
 
     implementation("androidx.browser:browser:1.8.0")
     implementation("com.google.android.gms:play-services-auth:21.2.0")

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -16,7 +16,7 @@ allprojects {
 }
 
 dependencies{
-    implementation("com.github.outsystems:osinappbrowser-android:1.2.0-dev3@aar")
+    implementation("com.github.outsystems:osinappbrowser-android:1.2.1@aar")
 
     implementation("androidx.browser:browser:1.8.0")
     implementation("com.google.android.gms:play-services-auth:21.2.0")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updates the dependency to `OSInAppBrowserLib-Android`, removing unnecessary dependencies from the `AndroidManifest.xml` file.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3987

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested selecting a file in the WebView (using file.io) on Android 15 and Android 12 device.

MABS build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=1c0e7981f2efee4671c588d93ef5a0a1d331f697&stg=dev

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
