### PR TITLE
ci: update azure pipeline image to the ubuntu 24.04

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -13,7 +13,7 @@ resources:
 trigger: none
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-24.04
 variables:
   - name: StampsInformationFileName
     value: eng-mobile.StampsInformation.json


### PR DESCRIPTION
The Ubuntu-20.04 image for the Microsoft-hosted Azure Pipelines pool is being deprecated and will be retired on April 1st.

Please review the [official announcement and the brownout schedule](http://aka.ms/azdo-ubuntu-20.04) for more details. 

We can either lock to ubuntu 24 or use the latest.