### PR TITLE
fix: prevent alert view dismiss from triggering onBrowserClosed event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### Fixes
+
+- iOS: Fixes an issue where dismissing an alert view triggered the onBrowserClosed event. [RMET-4500](https://outsystemsrd.atlassian.net/browse/RMET-4500).
+
 ## 1.6.0
 
 ### Features

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="OSInAppBrowserLib" spec="2.1.0" />
+                <pod name="OSInAppBrowserLib" spec="2.2.1" />
             </pods>
         </podspec> 
     </platform>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes an issue where dismissing an alert view triggered the onBrowserClosed event.



## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
https://outsystemsrd.atlassian.net/browse/RMET-4500

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [X] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RMET-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly