### PR TITLE
RMET-5110 ::: Prepare to release version 1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 1.6.4
+
+### Fixes
+
+- iOS: Fixed an issue where `window.open()` calls and links with `target="_blank"` were not handled in the OpenInWebView option, causing navigation to fail. [RMET-5110](https://outsystemsrd.atlassian.net/browse/RMET-5110)
+
 ## 1.6.3
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.inappbrowser",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "InAppBrowser OutSystems Cordova Plugin",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.outsystems.plugins.inappbrowser" version="1.6.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.inappbrowser" version="1.6.4" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>cordova-outsystems-inappbrowser</name>
     <description>InAppBrowser OutSystems Cordova Plugin</description>
     <author>OutSystems Inc</author>
@@ -45,7 +45,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="OSInAppBrowserLib" spec="2.3.1" />
+                <pod name="OSInAppBrowserLib" spec="2.3.2" />
             </pods>
         </podspec> 
     </platform>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Bumps `OSInAppBrowserLib` iOS native dependency to `2.3.2`, which fixes an issue where window.open() calls and links with `target="_blank"` were not being handled when using the `OpenInWebView` option, causing navigation to fail.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
Addresses: https://outsystemsrd.atlassian.net/browse/RMET-5110

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly