### PR TITLE
fix(android): Duplicate requests for checking if a url hosts PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 1.6.5
+
+### Fixes
+
+- android: Remove extra requests for checking if a URL hosts a PDF with `openInWebView`. This makes sure that for non-PDF urls, no extra request to the webpage/server is done [RMET-5141](https://outsystemsrd.atlassian.net/browse/RMET-5141) / [RPM-6744](https://outsystemsrd.atlassian.net/browse/RPM-6744).
+
 ## 1.6.4
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.inappbrowser",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "InAppBrowser OutSystems Cordova Plugin",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.outsystems.plugins.inappbrowser" version="1.6.4" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.inappbrowser" version="1.6.5" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>cordova-outsystems-inappbrowser</name>
     <description>InAppBrowser OutSystems Cordova Plugin</description>
     <author>OutSystems Inc</author>

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 dependencies{
-    implementation("io.ionic.libs:ioninappbrowser-android:1.6.1@aar")
+    implementation("io.ionic.libs:ioninappbrowser-android:1.6.2@aar")
 
     implementation("androidx.browser:browser:1.8.0")
     implementation("com.google.android.gms:play-services-auth:21.2.0")


### PR DESCRIPTION
## Description

This PR fixes an issue on ASPX and OutSystems Traditional Web Apps where multiple requests (besides loading the webpage, we were previously trying to do HTTP requests to check if the url was for a pdf file) were triggering "Preparation" server action more than once when loading said web page in a WebView, even if the web page hosted no PDFs.

## Context

Fix done via native library update.

References:

- https://outsystemsrd.atlassian.net/browse/RMET-5141
- https://outsystemsrd.atlassian.net/browse/RPM-6744
- https://github.com/OutSystems/OSInAppBrowserLib-Android/pull/56

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests

In our O11 environment, you may use the "InAppBrowser Sample App" to test general functionality, and "RMET-5141 Mobile Test" to confirm that the bug is fixed.

Further testing notes in the **Test** section in https://github.com/OutSystems/OSInAppBrowserLib-Android/pull/56.
