### PR TITLE
fix(android): bump ioninappbrowser-android to 2.0.1 for Android 18 URI grant fix

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 dependencies{
-    implementation("io.ionic.libs:ioninappbrowser-android:2.0.0@aar")
+    implementation("io.ionic.libs:ioninappbrowser-android:2.0.1@aar")
 
     implementation("androidx.browser:browser:1.8.0")
     implementation("com.google.android.gms:play-services-auth:21.2.0")


### PR DESCRIPTION
## Description
This plugin delegates entirely to `OSIABEngine`/`OSIABRouter` in `OSInAppBrowserLib-Android`. Bumped `ioninappbrowser-android` from 2.0.0 to 2.0.1, which explicitly grants `FLAG_GRANT_READ_URI_PERMISSION`/`FLAG_GRANT_WRITE_URI_PERMISSION` on the WebView file-chooser capture intents — see [OSInAppBrowserLib-Android#57](https://github.com/OutSystems/OSInAppBrowserLib-Android/pull/57).

## Context
Android 18 removes automatic URI permission grants for `ACTION_IMAGE_CAPTURE` intents (and similarly affects `ACTION_VIDEO_CAPTURE`) — apps must now explicitly request read/write access, or the camera app silently fails to write the captured media back into the URI.

[RMET-5241](https://outsystemsrd.atlassian.net/browse/RMET-5241)

**Draft**: `ioninappbrowser-android:2.0.1` is not yet published to Maven Central — this PR is blocked on that release landing. Do not merge until then.

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
No code in this plugin changes behavior directly; it shares the identical `OSIABEngine`/`OSIABRouter` call path already verified working (Android 8 and Android 17) via `capacitor-os-inappbrowser`'s example app built against the same fix.

Also tested with [MABS 12 build](https://eng-mobile.outsystems.dev/apps/application?id=b5db1611-19de-4849-ae6a-5a6ceb532286&tab=mobiledistribution&stageid=82798f0c-48de-4787-b0e1-dd3204ce2e6b&mobileoption=android)

## Screenshots (if appropriate)
N/A

## Checklist
- [x] Code follows code style of this project
- [x] Using [conventional commits](https://www.conventionalcommits.org/)
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly

[RMET-5241]: https://outsystemsrd.atlassian.net/browse/RMET-5241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ